### PR TITLE
emerge: add support for sets completion

### DIFF
--- a/completions/emerge
+++ b/completions/emerge
@@ -26,6 +26,12 @@ _emerge()
         return 0
     fi
 
+    if [[ ${cur} =~ ^@ ]] ; then
+        local SET_LIST=($(emerge --list-sets))
+        COMPREPLY=($(compgen -W '${SET_LIST[@]/#/@}' ${cur}))
+        return 0
+    fi
+
     # find action
     for x in ${COMP_LINE} ; do
         if [[ ${x} =~ ^(system|world)$ ]] || [[ ${x} =~ -[CPcs] ]] || \


### PR DESCRIPTION
Based on Marco Genasci's patch and slightly modified to get rid of the
unnecessary call to xargs.

Thanks-to: Marco Genasci @fedeliallalinea
Closes: https://bugs.gentoo.org/235454