### PR TITLE
ignore non conf files in /etc/portage/repos.conf/

### DIFF
--- a/helpers/gentoo-common.sh
+++ b/helpers/gentoo-common.sh
@@ -7,7 +7,7 @@
 # Retrieve PORTDIR/PORTDIR_OVERLAY location.
 #
 # In order of highest to lowest priority:
-# /etc/portage/repos.conf{,/*}
+# /etc/portage/repos.conf{,/*.conf}
 # /usr/share/portage/config/repos.conf
 # /etc/portage/make.conf
 # /etc/make.conf
@@ -65,7 +65,7 @@ _parsereposconf() {
 
     for f in @GENTOO_PORTAGE_EPREFIX@/usr/share/portage/config/repos.conf \
         @GENTOO_PORTAGE_EPREFIX@/etc/portage/repos.conf \
-        @GENTOO_PORTAGE_EPREFIX@/etc/portage/repos.conf/*; do
+        @GENTOO_PORTAGE_EPREFIX@/etc/portage/repos.conf/*.conf; do
 
         [[ -f ${f} ]] || continue
         insection=0


### PR DESCRIPTION
portage ignores any file in /etc/portage/repos.conf/ (when that is in
fact a directory) that does not have a name of the form "*.conf".

gentoo-bashcomp should emulate the behavior of portage. Otherwise you
might run into issues: e.g. if there is a backup of eselect-repo.conf
called eselect-repo.conf~ that contains references to a now removed
overlay, gentoo-bashcomp should not try to search for completions in the
now nonexistent repo directory